### PR TITLE
Updated the API document. #32

### DIFF
--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   description: ""
-  version: "0.0.1"
+  version: "0.1.0"
   title: "Swagger Petstore"
 servers:
   - url: /v1
@@ -9,28 +9,17 @@ tags:
 - name: "Similarity"
   description: "Post reviews and get the simirality between a reviewer and a user"
 paths:
-  /users/{userId}/reviewers/{reviewerId}/similarity:
+  /profile/similarity:
     post:
       tags:
       - "Similarity"
       summary: "Get similarity from posted reviews"
-      parameters:
-        - in: path
-          name: userId
-          required: true
-          schema:
-            type: string
-        - in: path
-          name: reviewerId
-          required: true 
-          schema:
-            type: string
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Reviews"
+              $ref: "#/components/schemas/Data"
       responses:
         201:
           description: "Similarity between a user and a reviewer"
@@ -47,17 +36,22 @@ components:
       in: header       
       name: X-API-KEY
   schemas:
-    Reviews:
+    Data:
       type: "object"
       required:
       - "reviews"
       properties:
-        reviews:
-          type: "array"
-          items:
-            type: "string"
+        user_id:
+          type: "string"
+        user_text:
+          type: "string"
+        reviewer_id:
+          type: "string"
+        reviewer_text:
+          type: "string"
     ReviewsResponse:
       type: "object"
       properties:
         similarity:
-          type: integer
+          type: number
+          format: float


### PR DESCRIPTION
#32 

実装コスト低減のため,一つのendpointですべて処理するように変更.

- Pathパラメータを削除.
- パラメータをreviewsからuser_id, user_text, reviewer_id, reviewer_txtの4つへ変更.


大体↓のような感じで処理する.
user_txtに当たるTweetはExtension側で取得してLocalStorageに保存しておく.
これが空なら,Tweetを取得するように条件分岐する.

```
function similarity (user_id, user_txt, reviewer_id, reviewer_txt)
{
user = User(user_id)
reviewer = Reviewer(reviewer_id)
if ( user.profile == None )
{
user.profile = client.get_profile(user_txt)
user.save()
}
if ( reviewer.profile == None )
{
reviewer.profile = client.get_profile(reviewer_txt)
reviewer.save()
}
similarity = get_similarity(reviewer.profile, user.profile)

return Response(similarity)
```



